### PR TITLE
feat: add snackbar behavior for completed timers with persistent sound

### DIFF
--- a/src/components/timer/TimerItem.tsx
+++ b/src/components/timer/TimerItem.tsx
@@ -36,7 +36,7 @@ const TimerItem: React.FC<TimerItemProps> = ({ timer }) => {
             hasEndedRef.current = true;
             timerAudio.play().catch(console.error);
             toast.success(`Timer "${timer.title}" has ended!`, {
-              duration: 5000,
+              duration: Infinity,
               action: {
                 label: 'Dismiss',
                 onClick: timerAudio.stop.bind(timerAudio),

--- a/src/utils/audio.ts
+++ b/src/utils/audio.ts
@@ -49,12 +49,6 @@ export class TimerAudio {
 
       // Start and stop the oscillator
       this.oscillator.start(this.audioContext.currentTime);
-      this.oscillator.stop(this.audioContext.currentTime + 0.5);
-
-      // Cleanup after sound ends
-      setTimeout(() => {
-        this.cleanup();
-      }, 500);
     } catch (error) {
       console.error('Failed to play audio:', error);
     }


### PR DESCRIPTION
# PR Template & Definition of Done

## What does this PR do?

- Fixes #19 
- Implements persistent sound for snackbar notifications: the sound continues until the snackbar is manually dismissed by the user, making sure the user has full control over the notification.
- As mentioned in this [issue](https://github.com/emilkowalski/sonner/issues/327#issuecomment-1928635953) in Sonner's repository, used JavaScripts' [Infinity](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Infinity) for `duration` prop of `toast.success` to persist the snackbar till the user dismisses it.

## What steps does your reviewer have to take to test this PR manually?

1. Pull the branch `feat/19-snackbar-persistent-sound` and run the application locally.
2. Trigger a timer completion and verify that a snackbar notification appears.
3. Check that the notification sound continues playing until the snackbar is manually dismissed by the user.
4. Make sure that the snackbar stays open until the user dismisses it, and does not auto-dismiss after 5 seconds.

## Pull Request standards checklist - Please check off

- [x] This Branch will be carrying one single responsibility - **feature**.
- [x] I have followed conventional commit messages and descriptive Branch naming.
- [x] My PR has descriptive folder/file names that I have worked on.

## Testing checklist - Please check off

- [x] I have performed manual testing on my local to validate all changes.

## Definition of Done - Please check off

- [x] My code is well tested and I have confidence my code works as I expect in a variety of situations.
- [x] I have lint and format code is enabled when the file is saved and I have fixed all errors highlighted by lint.
- [x] I have deleted all non-descriptive comments and dead code from the files I've touched.
- [x] I have rebased my branch with the base branch I want to merge into and all the commits in this PR are my own.
