### PR TITLE
refactor: modfiy ErrorMessage component to move the hasError logic out of it and update usage

### DIFF
--- a/src/components/UI/ErrorMessage.tsx
+++ b/src/components/UI/ErrorMessage.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
+interface ErrorMessageProps {
+  errorMessage: string;
+}
 
-import { FormErrorType } from '@types/ui';
-
-const ErrorMessage: React.FC<FormErrorType> = ({ hasError, errorMessage }) =>
-  hasError ? <p className="mt-1 text-sm text-red-500">{errorMessage}</p> : '';
-
+const ErrorMessage: React.FC<ErrorMessageProps> = ({ errorMessage }) => (
+  <p className="mt-1 text-sm text-red-500">{errorMessage}</p>
+);
 export default ErrorMessage;

--- a/src/components/UI/Input.tsx
+++ b/src/components/UI/Input.tsx
@@ -30,9 +30,7 @@ const Input: React.FC<InputProps> = ({
             : `${required && hasError ? 'border-red-500' : 'border-gray-300'}`
         }`}
       />
-
-      <ErrorMessage hasError={hasError} errorMessage={errorMessage} />
-
+      {hasError ? <ErrorMessage errorMessage={errorMessage} /> : ''}
       {children}
     </FieldWrapper>
   );

--- a/src/components/UI/TextArea.tsx
+++ b/src/components/UI/TextArea.tsx
@@ -29,7 +29,7 @@ const TextArea: React.FC<TextAreaProps> = ({
         } w-full px-4 py-2 border rounded-md focus:outline-2 focus:outline-blue-500`}
       />
 
-      <ErrorMessage hasError={hasError} errorMessage={errorMessage} />
+      {hasError ? <ErrorMessage errorMessage={errorMessage} /> : ''}
 
       {children}
     </FieldWrapper>


### PR DESCRIPTION
# PR Template & Definition of Done

## What does this PR do?

- Fixes #25 
- Refactors the `ErrorMessage` component to remove the `hasError` logic.
- Updates the usage of `ErrorMessage` in parent components to handle error logic externally.

## What steps does your reviewer have to take to test this PR manually?

1. Pull the branch `refactor/25-move-error-handling-logic-out-of-error-message-component` and run the application locally.
2. Review the changes in `ErrorMessage.tsx` to make sure the `hasError` logic is removed and the component only handles displaying the message.
3. Review the updated usage of `ErrorMessage` in parent components to confirm that error handling logic is correctly implemented externally.


## Pull Request standards checklist - Please check off

- [x] This Branch will be carrying one single responsibility - **refactor**.
- [x] I have followed conventional commit messages and descriptive Branch naming.
- [ ] My PR has descriptive folder/file names that I have worked on.

## Testing checklist - Please check off

- [x] I have performed manual testing on my local to validate all changes.

## Definition of Done - Please check off

- [x] My code is well tested and I have confidence my code works as I expect in a variety of situations.
- [x] I have lint and format code is enabled when the file is saved and I have fixed all errors highlighted by lint.
- [x] I have deleted all non-descriptive comments and dead code from the files I've touched.
- [x] I have rebased my branch with the base branch I want to merge into and all the commits in this PR are my own.
