### PR TITLE
fix: display validation snackbar errors to the user on timer modal form submission

### DIFF
--- a/src/components/timer/Modal/TimerModal.tsx
+++ b/src/components/timer/Modal/TimerModal.tsx
@@ -1,10 +1,18 @@
 import React, { useState } from 'react';
+// import { toast } from 'sonner';
 
 import { useTimerStore } from '@custom-hooks';
 import { validateTimerForm } from '@utils/validation';
 import { Timer } from '@types/timer';
 
-import { Input, TextArea, FieldWrapper, PrimaryButton, SecondaryButton } from '@ui-components';
+import {
+  Input,
+  TextArea,
+  FieldWrapper,
+  PrimaryButton,
+  SecondaryButton,
+  ErrorMessage,
+} from '@ui-components';
 import { ModalWrapper } from '@components/timer';
 
 interface TimerModalProps {
@@ -26,6 +34,7 @@ const TimerModal: React.FC<TimerModalProps> = ({ onClose, timer, isEditMode = fa
     seconds: false,
   });
 
+  const hasTouchedTimeFields = touched.hours || touched.minutes || touched.seconds;
   const { addTimer, editTimer } = useTimerStore();
 
   const handleSubmit = (e: React.FormEvent) => {
@@ -134,6 +143,9 @@ const TimerModal: React.FC<TimerModalProps> = ({ onClose, timer, isEditMode = fa
               onBlur={() => setTouched({ ...touched, seconds: true })}
             />
           </div>
+          {!isTimeValid && hasTouchedTimeFields ? (
+            <ErrorMessage errorMessage={'Please set a time greater than 0'} />
+          ) : null}
         </FieldWrapper>
 
         <div className="flex justify-end gap-3 pt-4 border-t">
@@ -144,9 +156,7 @@ const TimerModal: React.FC<TimerModalProps> = ({ onClose, timer, isEditMode = fa
           >
             Cancel
           </SecondaryButton>
-          <PrimaryButton type="submit" disabled={!isTitleValid || !isTimeValid}>
-            {isEditMode ? 'Save Changes' : 'Add Timer'}
-          </PrimaryButton>
+          <PrimaryButton type="submit">{isEditMode ? 'Save Changes' : 'Add Timer'}</PrimaryButton>
         </div>
       </form>
     </ModalWrapper>


### PR DESCRIPTION
# PR Template & Definition of Done

## What does this PR do?

- Fixes #28 
- Enables the form button even when validation errors are present, making sure that snackbar error messages are shown to the user upon clicking it.
- To maintain a good user experience, validation errors will also be visibly displayed on the screen, as toast messages disappear after a few seconds and might be missed.

## What steps does your reviewer have to take to test this PR manually?

1. Pull the branch `fix/28-display-snackbar-error-on-form-submission` and run the application locally.
2. Navigate to the Timer Modal (either Add or Edit).
3. Try submitting the form without entering a title or valid duration.
4. Observe that a validation snackbar appears to notify the user of errors, in addition to inline messages.

## Pull Request standards checklist - Please check off

- [x] This Branch will be carrying one single responsibility - **fix**.
- [x] I have followed conventional commit messages and descriptive Branch naming.
- [x] My PR has descriptive folder/file names that I have worked on.

## Testing checklist - Please check off

- [x] I have performed manual testing on my local to validate all changes.

## Definition of Done - Please check off

- [x] My code is well tested and I have confidence my code works as I expect in a variety of situations.
- [x] I have lint and format code is enabled when the file is saved and I have fixed all errors highlighted by lint.
- [x] I have deleted all non-descriptive comments and dead code from the files I've touched.
- [x] I have rebased my branch with the base branch I want to merge into and all the commits in this PR are my own.
